### PR TITLE
Only build container image for tags

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -4,7 +4,6 @@ name: "Build and publish container image"
 on:  # yamllint disable-line rule:truthy
   push:
     tags: ["*"]
-    branches: ["*"]
 
 jobs:
   build_and_publish:


### PR DESCRIPTION
save resources by not constantly rebuilding the container image.